### PR TITLE
Support ics20 transfer memo field without changing cosmwasm-std

### DIFF
--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -278,6 +278,8 @@ func EncodeIBCMsg(portSource types.ICS20TransferPortSource) func(ctx sdk.Context
 			if err != nil {
 				return nil, sdkerrors.Wrap(err, "amount")
 			}
+			// A comma is safe to use as a separator as it is an invalid character for channel id and won't be present without a memo
+			// https://github.com/cosmos/ibc/tree/main/spec/core/ics-024-host-requirements#paths-identifiers-separators
 			channelID, memo, _ := strings.Cut(msg.Transfer.ChannelID, ",")
 			msg := &ibctransfertypes.MsgTransfer{
 				SourcePort:       portSource.GetPort(ctx),

--- a/x/wasm/keeper/handler_plugin_encoders.go
+++ b/x/wasm/keeper/handler_plugin_encoders.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	wasmvmtypes "github.com/CosmWasm/wasmvm/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -277,14 +278,16 @@ func EncodeIBCMsg(portSource types.ICS20TransferPortSource) func(ctx sdk.Context
 			if err != nil {
 				return nil, sdkerrors.Wrap(err, "amount")
 			}
+			channelID, memo, _ := strings.Cut(msg.Transfer.ChannelID, ",")
 			msg := &ibctransfertypes.MsgTransfer{
 				SourcePort:       portSource.GetPort(ctx),
-				SourceChannel:    msg.Transfer.ChannelID,
+				SourceChannel:    channelID,
 				Token:            amount,
 				Sender:           sender.String(),
 				Receiver:         msg.Transfer.ToAddress,
 				TimeoutHeight:    ConvertWasmIBCTimeoutHeightToCosmosHeight(msg.Transfer.Timeout.Block),
 				TimeoutTimestamp: msg.Transfer.Timeout.Timestamp,
+				Memo:             memo,
 			}
 			return []sdk.Msg{msg}, nil
 		default:


### PR DESCRIPTION
Cosmwasm does not support a memo field in IBCMsg.Transfer and won't until [cosmwasm v2.0.0](https://github.com/CosmWasm/cosmwasm/issues/1477). This patch allows using the channel id as an optional comma delimited string to piggyback a memo string. A comma is not a valid character for channel-id and so if it is present, it was added by a contract for a memo to be included.